### PR TITLE
Fix "undefined reference to `pthread_create'" error on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ message("gitversion = ${PROJECT_GIT_VERSION}")
 configure_file(${PROJECT_SOURCE_DIR}/config/config.h.in ${PROJECT_SOURCE_DIR}/config/config.h)
 
 SET(CMAKE_CXX_STANDARD 11)
-SET(CMAKE_CXX_FLAGS "-Wall")
+SET(CMAKE_CXX_FLAGS "-Wall -pthread")
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/config


### PR DESCRIPTION
The following error message prevented compiling on Ubuntu 18.10:

```bash
 $ make
[  3%] Building CXX object CMakeFiles/GoBattleSim.dir/src/Application.cpp.o
[  7%] Building CXX object CMakeFiles/GoBattleSim.dir/src/Battle.cpp.o
[ 10%] Building CXX object CMakeFiles/GoBattleSim.dir/src/BattleMatrix.cpp.o
[ 14%] Building CXX object CMakeFiles/GoBattleSim.dir/src/GameMaster.cpp.o
[ 17%] Building CXX object CMakeFiles/GoBattleSim.dir/src/GoBattleSim_extern.cpp.o
[ 21%] Building CXX object CMakeFiles/GoBattleSim.dir/src/Party.cpp.o
[ 25%] Building CXX object CMakeFiles/GoBattleSim.dir/src/Player.cpp.o
[ 28%] Building CXX object CMakeFiles/GoBattleSim.dir/src/Pokemon.cpp.o
[ 32%] Building CXX object CMakeFiles/GoBattleSim.dir/src/PokemonState.cpp.o
[ 35%] Building CXX object CMakeFiles/GoBattleSim.dir/src/PvPPokemon.cpp.o
[ 39%] Building CXX object CMakeFiles/GoBattleSim.dir/src/PvPStrategy.cpp.o
[ 42%] Building CXX object CMakeFiles/GoBattleSim.dir/src/SimplePvPBattle.cpp.o
[ 46%] Building CXX object CMakeFiles/GoBattleSim.dir/src/Strategy.cpp.o
[ 50%] Linking CXX shared library libGoBattleSim.so
[ 50%] Built target GoBattleSim
[ 53%] Building CXX object CMakeFiles/test_Raid_Battle.dir/test/unit_test/test_Raid_Battle.cpp.o
[ 57%] Linking CXX executable test_Raid_Battle
/usr/bin/ld: libGoBattleSim.so: undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/test_Raid_Battle.dir/build.make:104: test_Raid_Battle] Error 1
make[1]: *** [CMakeFiles/Makefile2:136: CMakeFiles/test_Raid_Battle.dir/all] Error 2
make: *** [Makefile:114: all] Error 2
```

Fixed by adding the `-pthread` compile option.